### PR TITLE
Update index.js Strict Mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-disable no-sync */
 const _ = require('lodash')
 const sharp = require('sharp')


### PR DESCRIPTION
Fix 'SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode'